### PR TITLE
Improve .gitignore for Gradle project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,16 @@
-# Ignore Gradle project-specific cache directory
-.gradle
+# Build outputs
+/build/
+**/build/
+*.class
 
-# Ignore Gradle build output directory
-build
+# Gradle
+.gradle/
+!gradle/wrapper/gradle-wrapper.jar
+
+# IDEs
+.idea/
+.vscode/
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- extend `.gitignore` for build artifacts
- ignore Gradle cache while keeping `gradle-wrapper.jar`
- add IDE and OS specific ignores

## Testing
- `sh ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_684260b581d88321aa56f95ea93e7d38